### PR TITLE
fix: remove double `|` when activity is missing

### DIFF
--- a/src/components/entity/ELevel.tsx
+++ b/src/components/entity/ELevel.tsx
@@ -26,8 +26,12 @@ export const NeoELevel: FC<{
       <div className="flex items-center">
         <div className="flex whitespace-pre">
           <span className="inline-block font-bold my-auto">{catThree}</span>
-          {' | '}
-          <span className="text-xs">{catTwo}</span>
+          {catTwo && (
+            <>
+              {' | '}
+              <span className="text-xs">{catTwo}</span>
+            </>
+          )}
           {' | '}
           <span className="text-xs">{catOne}</span>
         </div>


### PR DESCRIPTION
![{CFE9288D-24C9-4F9D-B251-A3FC34BDC938}](https://github.com/user-attachments/assets/6bf89491-0579-4136-86ce-cf35e0a35bae)
![{AC61533E-E9B0-4CE4-BD41-638584A6AC31}](https://github.com/user-attachments/assets/17d40922-7e8d-43e9-980d-989f590d11b9)
Images explain themselves.

Was the double `| |` wanted? Because personally it doesn't look that good?