### PR TITLE
fix: operator direction arrow not active in dark mode

### DIFF
--- a/src/components/editor2/action/ActionItem.tsx
+++ b/src/components/editor2/action/ActionItem.tsx
@@ -107,7 +107,7 @@ export const ActionItem: FC<ActionItemProps> = memo(
             typeInfo.accentText,
           )}
         >
-          <div className="flex flex-wrap items-center">
+          <div className="flex flex-wrap items-center !text-inherit">
             <h4
               className={clsx(
                 'relative shrink-0 self-stretch w-[5em] text-2xl font-serif bg-gray-100 dark:bg-gray-700 cursor-move select-none touch-manipulation',


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b0dc1cf8-0145-46fc-803f-ee0bf8252ae2)

坐标位置需要在暗黑模式加上主题色吗，这块我不知道是不是feature