### PR TITLE
feat: 为作业集添加干员卡片

### DIFF
--- a/src/components/OperatorCard.tsx
+++ b/src/components/OperatorCard.tsx
@@ -10,14 +10,31 @@ import { OPERATORS, getEliteIconUrl, getModuleName, getSkillCount, useLocalizedO
 import { MasteryIcon } from './MasteryIcon'
 import { OperatorAvatar } from './OperatorAvatar'
 
+export interface OperatorCardSkill {
+  skill: number
+  skillLevel?: number
+}
+
 export const OperatorCard: FC<{
   operator: CopilotDocV1.Operator
-}> = ({ operator }) => {
+  skills?: readonly OperatorCardSkill[]
+  modules?: readonly CopilotDocV1.Module[]
+}> = ({ operator, skills, modules }) => {
   const t = useTranslation()
   const displayName = useLocalizedOperatorName(operator.name)
   const info = OPERATORS.find((o) => o.name === operator.name)
   const { level, elite, skillLevel, module } = operator.requirements ?? {}
-  const skillCount = info ? Math.max(getSkillCount(info), operator.skill ?? 1) : 3
+  const selectedSkills =
+    skills ?? (operator.skill === undefined ? [] : [{ skill: operator.skill, skillLevel } satisfies OperatorCardSkill])
+  const selectedModules = Array.from(
+    new Set(
+      (modules ?? (module === undefined ? [] : [module])).filter(
+        (selectedModule) => selectedModule !== CopilotDocV1.Module.Default,
+      ),
+    ),
+  ).sort((a, b) => a - b)
+  const highestSelectedSkill = selectedSkills.reduce((highest, selected) => Math.max(highest, selected.skill), 0)
+  const skillCount = Math.max(info ? getSkillCount(info) : 3, highestSelectedSkill, operator.skill ?? 1)
 
   return (
     <div className="relative flex items-start">
@@ -30,15 +47,24 @@ export const OperatorCard: FC<{
             fallback={displayName}
             sourceSize={96}
           />
-          {module !== undefined && module !== CopilotDocV1.Module.Default && (
-            <div
-              title={t.components.viewer.OperationViewer.module_title({
-                count: module,
-                name: getModuleName(module),
-              })}
-              className="absolute -bottom-1 right-1 font-serif font-bold text-lg text-white [text-shadow:0_0_3px_#a855f7,0_0_5px_#a855f7]"
-            >
-              {module === CopilotDocV1.Module.Original ? <Icon icon="small-square" /> : getModuleName(module)}
+          {selectedModules.length > 0 && (
+            <div className="absolute -bottom-1 right-1 flex items-center gap-0.5 font-serif font-bold text-lg text-white [text-shadow:0_0_3px_#a855f7,0_0_5px_#a855f7]">
+              {selectedModules.map((selectedModule) => (
+                <span
+                  key={selectedModule}
+                  className="inline-flex items-center"
+                  title={t.components.viewer.OperationViewer.module_title({
+                    count: selectedModule,
+                    name: getModuleName(selectedModule),
+                  })}
+                >
+                  {selectedModule === CopilotDocV1.Module.Original ? (
+                    <Icon icon="small-square" />
+                  ) : (
+                    getModuleName(selectedModule)
+                  )}
+                </span>
+              ))}
             </div>
           )}
         </div>
@@ -69,7 +95,8 @@ export const OperatorCard: FC<{
       <ul className="flex flex-col gap-1 ml-1">
         {Array.from({ length: skillCount }, (_, index) => {
           const skillNumber = index + 1
-          const selected = operator.skill === skillNumber
+          const selectedSkill = selectedSkills.find((selected) => selected.skill === skillNumber)
+          const selected = selectedSkill !== undefined
           return (
             <li
               key={index}
@@ -83,14 +110,14 @@ export const OperatorCard: FC<{
             >
               <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
                 {selected &&
-                  (skillLevel === undefined ? (
+                  (selectedSkill.skillLevel === undefined ? (
                     <Icon icon="tick" />
-                  ) : skillLevel <= 7 ? (
-                    skillLevel
+                  ) : selectedSkill.skillLevel <= 7 ? (
+                    selectedSkill.skillLevel
                   ) : (
                     <MasteryIcon
                       className="w-4 h-4"
-                      mastery={skillLevel - 7}
+                      mastery={selectedSkill.skillLevel - 7}
                       subClassName="fill-gray-300 dark:fill-gray-500"
                     />
                   ))}

--- a/src/components/OperatorCard.tsx
+++ b/src/components/OperatorCard.tsx
@@ -26,7 +26,6 @@ export const OperatorCard: FC<{
   const { level, elite, skillLevel, module } = operator.requirements ?? {}
   const selectedSkills =
     skills ?? (operator.skill === undefined ? [] : [{ skill: operator.skill, skillLevel } satisfies OperatorCardSkill])
-  const hasSelectedSkillLevel = selectedSkills.some((selectedSkill) => selectedSkill.skillLevel !== undefined)
   const selectedModules = Array.from(
     new Set(
       (modules ?? (module === undefined ? [] : [module])).filter(
@@ -110,9 +109,9 @@ export const OperatorCard: FC<{
               title={t.models.operator.skill_number({ count: skillNumber })}
             >
               <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
-                {selected ? (
-                  selectedSkill.skillLevel === undefined ? (
-                    selectedSkill.skill
+                {selected &&
+                  (selectedSkill.skillLevel === undefined ? (
+                    <Icon icon="tick" />
                   ) : selectedSkill.skillLevel <= 7 ? (
                     selectedSkill.skillLevel
                   ) : (
@@ -121,10 +120,7 @@ export const OperatorCard: FC<{
                       mastery={selectedSkill.skillLevel - 7}
                       subClassName="fill-gray-300 dark:fill-gray-500"
                     />
-                  )
-                ) : hasSelectedSkillLevel ? null : (
-                  skillNumber
-                )}
+                  ))}
               </div>
             </li>
           )

--- a/src/components/OperatorCard.tsx
+++ b/src/components/OperatorCard.tsx
@@ -1,0 +1,104 @@
+import { Icon } from '@blueprintjs/core'
+
+import clsx from 'clsx'
+import { FC } from 'react'
+
+import { useTranslation } from 'i18n/i18n'
+import { CopilotDocV1 } from 'models/copilot.schema'
+import { OPERATORS, getEliteIconUrl, getModuleName, getSkillCount, useLocalizedOperatorName } from 'models/operator'
+
+import { MasteryIcon } from './MasteryIcon'
+import { OperatorAvatar } from './OperatorAvatar'
+
+export const OperatorCard: FC<{
+  operator: CopilotDocV1.Operator
+}> = ({ operator }) => {
+  const t = useTranslation()
+  const displayName = useLocalizedOperatorName(operator.name)
+  const info = OPERATORS.find((o) => o.name === operator.name)
+  const { level, elite, skillLevel, module } = operator.requirements ?? {}
+  const skillCount = info ? Math.max(getSkillCount(info), operator.skill ?? 1) : 3
+
+  return (
+    <div className="relative flex items-start">
+      <div className="relative w-20">
+        <div className="relative rounded-lg overflow-hidden shadow-md">
+          <OperatorAvatar
+            id={info?.id}
+            rarity={info?.rarity}
+            className="w-20 h-20"
+            fallback={displayName}
+            sourceSize={96}
+          />
+          {module !== undefined && module !== CopilotDocV1.Module.Default && (
+            <div
+              title={t.components.viewer.OperationViewer.module_title({
+                count: module,
+                name: getModuleName(module),
+              })}
+              className="absolute -bottom-1 right-1 font-serif font-bold text-lg text-white [text-shadow:0_0_3px_#a855f7,0_0_5px_#a855f7]"
+            >
+              {module === CopilotDocV1.Module.Original ? <Icon icon="small-square" /> : getModuleName(module)}
+            </div>
+          )}
+        </div>
+        <h4 className="mt-1 -mx-2 leading-4 font-semibold tracking-tighter text-center">{displayName}</h4>
+        {info && info.prof !== 'TOKEN' && (
+          <img
+            className="absolute top-0 right-0 w-5 h-5 p-px bg-gray-600 rounded-tr-md"
+            src={'/assets/prof-icons/' + info.prof + '.png'}
+            alt={info.prof}
+          />
+        )}
+      </div>
+      {level !== undefined && elite !== undefined && (
+        <div className="absolute -top-2 -left-4 flex items-center flex-col-reverse">
+          <div className="-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
+            <img
+              className="w-7 h-6 object-contain pointer-events-auto"
+              src={getEliteIconUrl(elite)}
+              alt={t.models.operator.elite({ level: elite })}
+            />
+          </div>
+          <div className="w-8 h-8 leading-7 rounded-full border-2 border-yellow-300 bg-black/50 text-lg text-white font-semibold text-center shadow-[0_1px_2px_rgba(0,0,0,0.9)]">
+            {level}
+          </div>
+        </div>
+      )}
+
+      <ul className="flex flex-col gap-1 ml-1">
+        {Array.from({ length: skillCount }, (_, index) => {
+          const skillNumber = index + 1
+          const selected = operator.skill === skillNumber
+          return (
+            <li
+              key={index}
+              className={clsx(
+                'relative',
+                selected
+                  ? 'bg-purple-100 dark:bg-purple-900 dark:text-purple-200 text-purple-800'
+                  : 'bg-gray-300 dark:bg-gray-600 opacity-15 dark:opacity-25',
+              )}
+              title={t.models.operator.skill_number({ count: skillNumber })}
+            >
+              <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
+                {selected &&
+                  (skillLevel === undefined ? (
+                    <Icon icon="tick" />
+                  ) : skillLevel <= 7 ? (
+                    skillLevel
+                  ) : (
+                    <MasteryIcon
+                      className="w-4 h-4"
+                      mastery={skillLevel - 7}
+                      subClassName="fill-gray-300 dark:fill-gray-500"
+                    />
+                  ))}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/OperatorCard.tsx
+++ b/src/components/OperatorCard.tsx
@@ -26,6 +26,7 @@ export const OperatorCard: FC<{
   const { level, elite, skillLevel, module } = operator.requirements ?? {}
   const selectedSkills =
     skills ?? (operator.skill === undefined ? [] : [{ skill: operator.skill, skillLevel } satisfies OperatorCardSkill])
+  const hasSelectedSkillLevel = selectedSkills.some((selectedSkill) => selectedSkill.skillLevel !== undefined)
   const selectedModules = Array.from(
     new Set(
       (modules ?? (module === undefined ? [] : [module])).filter(
@@ -121,7 +122,7 @@ export const OperatorCard: FC<{
                       subClassName="fill-gray-300 dark:fill-gray-500"
                     />
                   )
-                ) : (
+                ) : hasSelectedSkillLevel ? null : (
                   skillNumber
                 )}
               </div>

--- a/src/components/OperatorCard.tsx
+++ b/src/components/OperatorCard.tsx
@@ -109,9 +109,9 @@ export const OperatorCard: FC<{
               title={t.models.operator.skill_number({ count: skillNumber })}
             >
               <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
-                {selected &&
-                  (selectedSkill.skillLevel === undefined ? (
-                    <Icon icon="tick" />
+                {selected ? (
+                  selectedSkill.skillLevel === undefined ? (
+                    selectedSkill.skill
                   ) : selectedSkill.skillLevel <= 7 ? (
                     selectedSkill.skillLevel
                   ) : (
@@ -120,7 +120,10 @@ export const OperatorCard: FC<{
                       mastery={selectedSkill.skillLevel - 7}
                       subClassName="fill-gray-300 dark:fill-gray-500"
                     />
-                  ))}
+                  )
+                ) : (
+                  skillNumber
+                )}
               </div>
             </li>
           )

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -295,7 +295,7 @@ function OperationSetViewerOperatorsSection({ operationSet }: { operationSet: Op
       <Collapse isOpen={showOperators}>
         {exceedsAggregationLimit ? (
           <Callout intent="warning" className="mt-2">
-            {t.components.viewer.OperationSetViewer.operators_over_limit}
+            {t.components.viewer.OperationSetViewer.operations_over_limit}
           </Callout>
         ) : (
           <ErrorBoundary
@@ -432,7 +432,7 @@ function OperationSetViewerOperators({
     <div className="mt-2 select-none tabular-nums">
       {missingOperationCount > 0 && (
         <Callout intent="warning" className="mb-4">
-          {t.components.viewer.OperationSetViewer.operators_incomplete({ count: missingOperationCount })}
+          {t.components.viewer.OperationSetViewer.operations_incomplete({ count: missingOperationCount })}
         </Callout>
       )}
 

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -285,14 +285,6 @@ function OperationSetViewerOperatorsSection({ operationSet }: { operationSet: Op
         {t.components.viewer.OperationSetViewer.operators}
         <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
       </H4>
-      <details className="inline">
-        <summary className="inline cursor-pointer">
-          <Icon icon="help" size={14} className="ml-2 mb-1 opacity-50" />
-        </summary>
-        <Callout intent="primary" icon={null} className="mb-4">
-          <p>{t.components.viewer.OperationSetViewer.operators_help}</p>
-        </Callout>
-      </details>
 
       <Collapse isOpen={showOperators}>
         {exceedsAggregationLimit ? (

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -1,6 +1,8 @@
 import {
   Alert,
   Button,
+  Callout,
+  Collapse,
   H3,
   H4,
   H5,
@@ -10,32 +12,33 @@ import {
   NonIdealState,
   PopoverNext,
   Spinner,
-  Tooltip,
 } from '@blueprintjs/core'
 import { ErrorBoundary } from '@sentry/react'
 
 import { useOperations, type OperationsData } from 'apis/operation'
 import { deleteOperationSet, useOperationSet, useRefreshOperationSets } from 'apis/operation-set'
-import { useAtom, useAtomValue } from 'jotai'
+import clsx from 'clsx'
+import { useAtom } from 'jotai'
 import { ComponentType, FC, Suspense, useEffect, useState } from 'react'
 import { copyShortCode } from 'services/operation'
 
 import { FactItem } from 'components/FactItem'
 import { OperationListView } from 'components/OperationList'
+import { OperatorCard, type OperatorCardSkill } from 'components/OperatorCard'
 import { Paragraphs } from 'components/Paragraphs'
 import { RelativeTime } from 'components/RelativeTime'
 import { withSuspensable } from 'components/Suspensable'
 import { AppToaster } from 'components/Toaster'
 import { DrawerLayout } from 'components/drawer/DrawerLayout'
 import { OperationSetEditorDialog } from 'components/operation-set/OperationSetEditor'
-import { OperatorAvatar } from 'components/OperatorAvatar'
+import { CopilotDocV1 } from 'models/copilot.schema'
 import { Operation } from 'models/operation'
-import { findOperatorByName, getLocalizedOperatorName } from 'models/operator'
+import { OPERATORS } from 'models/operator'
 import { OperationSet } from 'models/operation-set'
 import { authAtom } from 'store/auth'
 import { wrapErrorMessage } from 'utils/wrapErrorMessage'
 
-import { i18nDefer, languageAtom, useTranslation } from '../../i18n/i18n'
+import { i18nDefer, useTranslation } from '../../i18n/i18n'
 import { formatError } from '../../utils/error'
 import { UserName } from '../UserName'
 
@@ -210,46 +213,53 @@ function OperationSetViewerInner({ operationSet }: { operationSet: OperationSet 
 }
 
 function OperationSetViewerBody({ operationSet }: { operationSet: OperationSet }) {
-  const t = useTranslation()
   const hasDescription = Boolean(operationSet.description?.trim())
 
   return (
     <>
-      <div className="flex flex-col gap-2 md:grid md:grid-cols-2 md:gap-x-8">
+      <div className="flex flex-col gap-2 md:grid md:grid-cols-3 md:gap-x-8">
         <div
           className={
             hasDescription
-              ? 'flex flex-wrap items-start gap-x-4 select-none tabular-nums md:col-start-2 md:row-start-1'
+              ? 'flex flex-wrap items-start gap-x-4 select-none tabular-nums md:col-start-3 md:row-start-1'
               : 'flex flex-wrap items-start gap-x-4 select-none tabular-nums md:col-start-1 md:row-start-1'
           }
         >
-          <FactItem title={t.components.viewer.OperationSetViewer.published_at} icon="time">
-            <span className="text-gray-800 dark:text-slate-100 font-bold">
-              <RelativeTime moment={operationSet.createTime} />
-            </span>
-          </FactItem>
-
-          <FactItem title={t.components.viewer.OperationSetViewer.author} icon="user">
-            <UserName className="text-gray-800 dark:text-slate-100 font-bold" userId={operationSet.creatorId}>
-              {operationSet.creator}
-            </UserName>
-          </FactItem>
+          <OperationSetMetadata operationSet={operationSet} />
         </div>
 
         {hasDescription && (
-          <div className="flex flex-col md:col-start-1 md:row-start-1 md:row-span-2">
+          <div className="flex flex-col md:col-span-2 md:col-start-1 md:row-start-1">
             <Paragraphs content={operationSet.description} linkify />
           </div>
         )}
-
-        <div className={hasDescription ? 'md:col-start-2 md:row-start-2' : 'md:col-start-2 md:row-start-1'}>
-          <OperationSetViewerOperatorsSection operationSet={operationSet} />
-        </div>
       </div>
 
       <div className="h-[1px] w-full bg-gray-200 mt-4 mb-6" />
 
+      <OperationSetViewerOperatorsSection operationSet={operationSet} />
+
       <OperationSetViewerDetails operationSet={operationSet} />
+    </>
+  )
+}
+
+function OperationSetMetadata({ operationSet }: { operationSet: OperationSet }) {
+  const t = useTranslation()
+
+  return (
+    <>
+      <FactItem title={t.components.viewer.OperationSetViewer.published_at} icon="time">
+        <span className="text-gray-800 dark:text-slate-100 font-bold">
+          <RelativeTime moment={operationSet.createTime} />
+        </span>
+      </FactItem>
+
+      <FactItem title={t.components.viewer.OperationSetViewer.author} icon="user">
+        <UserName className="text-gray-800 dark:text-slate-100 font-bold" userId={operationSet.creatorId}>
+          {operationSet.creator}
+        </UserName>
+      </FactItem>
     </>
   )
 }
@@ -263,74 +273,185 @@ function useOperationSetOperations(operationSet: OperationSet) {
 
 function OperationSetViewerOperatorsSection({ operationSet }: { operationSet: OperationSet }) {
   const t = useTranslation()
+  const [showOperators, setShowOperators] = useState(true)
+  const exceedsAggregationLimit = operationSet.copilotIds.length > 50
 
   return (
-    <ErrorBoundary
-      key={operationSet.id}
-      fallback={({ error }) => (
-        <NonIdealState
-          icon="issue"
-          title={t.components.Suspensable.loadFailed}
-          description={error.message}
-          className="py-4"
-        />
-      )}
-    >
-      <Suspense
-        fallback={
-          <div className="flex items-center gap-2 py-4 text-slate-500">
-            <Spinner size={20} />
-            <span>{t.components.viewer.OperationSetViewer.loading_task_set}</span>
-          </div>
-        }
+    <div className="mb-6">
+      <H4
+        className="inline-flex items-center cursor-pointer hover:opacity-80"
+        onClick={() => setShowOperators((visible) => !visible)}
       >
-        <OperationSetViewerOperatorsLoader operationSet={operationSet} />
-      </Suspense>
-    </ErrorBoundary>
+        {t.components.viewer.OperationSetViewer.operators}
+        <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
+      </H4>
+      <details className="inline">
+        <summary className="inline cursor-pointer">
+          <Icon icon="help" size={14} className="ml-2 mb-1 opacity-50" />
+        </summary>
+        <Callout intent="primary" icon={null} className="mb-4">
+          <p>{t.components.viewer.OperationSetViewer.operators_help}</p>
+        </Callout>
+      </details>
+
+      <Collapse isOpen={showOperators}>
+        {exceedsAggregationLimit ? (
+          <Callout intent="warning" className="mt-2">
+            {t.components.viewer.OperationSetViewer.operators_over_limit}
+          </Callout>
+        ) : (
+          <ErrorBoundary
+            key={operationSet.id}
+            fallback={({ error }) => (
+              <NonIdealState
+                icon="issue"
+                title={t.components.Suspensable.loadFailed}
+                description={error.message}
+                className="py-4"
+              />
+            )}
+          >
+            <Suspense
+              fallback={
+                <div className="flex items-center gap-2 py-4 text-slate-500">
+                  <Spinner size={20} />
+                  <span>{t.components.viewer.OperationSetViewer.loading_task_set}</span>
+                </div>
+              }
+            >
+              <OperationSetViewerOperatorsLoader operationSet={operationSet} />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </Collapse>
+    </div>
   )
 }
 
 function OperationSetViewerOperatorsLoader({ operationSet }: { operationSet: OperationSet }) {
   const data = useOperationSetOperations(operationSet)
-  return <OperationSetViewerOperators operations={data.operations} />
+  return <OperationSetViewerOperators operationSet={operationSet} operations={data.operations} />
 }
 
-function OperationSetViewerOperators({ operations }: { operations: Operation[] }) {
-  const t = useTranslation()
-  const language = useAtomValue(languageAtom)
+interface AggregatedOperator {
+  operator: CopilotDocV1.Operator
+  skills: OperatorCardSkill[]
+  modules: CopilotDocV1.Module[]
+}
 
-  const rarityByName = new Map<string, number>()
-  const push = (name: string) => {
-    if (rarityByName.has(name)) return
-    rarityByName.set(name, findOperatorByName(name)?.rarity ?? 0)
-  }
+interface MutableAggregatedOperator {
+  name: string
+  skills: Map<number, number | undefined>
+  modules: Set<CopilotDocV1.Module>
+  requirements?: Pick<CopilotDocV1.Requirements, 'elite' | 'level'>
+}
+
+const OPERATOR_ORDER = new Map(
+  OPERATORS.map((operator, index) => [operator.name, { rarity: operator.rarity, index }] as const),
+)
+
+export function aggregateOperationSetOperators(operations: readonly Operation[]): AggregatedOperator[] {
+  const operatorsByName = new Map<string, MutableAggregatedOperator>()
 
   for (const operation of operations) {
-    // 干员组（groups[].opers）是“任选其一”的可替换干员，非确定使用，故头像区只展示明确指定的 opers
-    operation.parsedContent.opers?.forEach(({ name }) => push(name))
+    // 干员组表示“任选其一”，不属于作业集明确指定的所需干员。
+    for (const operator of operation.parsedContent.opers ?? []) {
+      let aggregated = operatorsByName.get(operator.name)
+      if (!aggregated) {
+        aggregated = {
+          name: operator.name,
+          skills: new Map(),
+          modules: new Set(),
+        }
+        operatorsByName.set(operator.name, aggregated)
+      }
+
+      const { elite, level, skillLevel, module } = operator.requirements ?? {}
+
+      if (operator.skill !== undefined) {
+        const currentSkillLevel = aggregated.skills.get(operator.skill)
+        if (
+          !aggregated.skills.has(operator.skill) ||
+          (skillLevel !== undefined && (currentSkillLevel === undefined || skillLevel > currentSkillLevel))
+        ) {
+          aggregated.skills.set(operator.skill, skillLevel)
+        }
+      }
+
+      if (
+        elite !== undefined &&
+        level !== undefined &&
+        (!aggregated.requirements ||
+          elite > aggregated.requirements.elite! ||
+          (elite === aggregated.requirements.elite && level > aggregated.requirements.level!))
+      ) {
+        aggregated.requirements = { elite, level }
+      }
+
+      if (module !== undefined && module !== CopilotDocV1.Module.Default) {
+        aggregated.modules.add(module)
+      }
+    }
   }
 
-  const operatorNames = Array.from(rarityByName.entries())
-    .sort(([, a], [, b]) => b - a)
-    .map(([name]) => name)
+  return Array.from(operatorsByName.values())
+    .sort((a, b) => {
+      const aOrder = OPERATOR_ORDER.get(a.name)
+      const bOrder = OPERATOR_ORDER.get(b.name)
+
+      if (aOrder && bOrder) {
+        return bOrder.rarity - aOrder.rarity || aOrder.index - bOrder.index
+      }
+      if (aOrder) return -1
+      if (bOrder) return 1
+      if (a.name === b.name) return 0
+      return a.name < b.name ? -1 : 1
+    })
+    .map(({ name, requirements, skills, modules }) => ({
+      operator: {
+        name,
+        ...(requirements && { requirements }),
+      },
+      skills: Array.from(skills, ([skill, skillLevel]) => ({ skill, skillLevel })).sort((a, b) => a.skill - b.skill),
+      modules: Array.from(modules).sort((a, b) => a - b),
+    }))
+}
+
+function OperationSetViewerOperators({
+  operationSet,
+  operations,
+}: {
+  operationSet: OperationSet
+  operations: Operation[]
+}) {
+  const t = useTranslation()
+  const operators = aggregateOperationSetOperators(operations)
+  const expectedOperationIds = new Set(operationSet.copilotIds)
+  const loadedOperationIds = new Set(operations.map((operation) => operation.id))
+  const missingOperationCount = Array.from(expectedOperationIds).filter((id) => !loadedOperationIds.has(id)).length
 
   return (
-    <div className="flex flex-col items-start select-none tabular-nums">
-      <FactItem title={t.components.viewer.OperationSetViewer.operators} icon="people">
-        {operatorNames.length === 0 ? (
-          <span className="text-gray-800 dark:text-slate-100 font-bold">
-            {t.components.viewer.OperationSetViewer.no_operators}
-          </span>
+    <div className="mt-2 select-none tabular-nums">
+      {missingOperationCount > 0 && (
+        <Callout intent="warning" className="mb-4">
+          {t.components.viewer.OperationSetViewer.operators_incomplete({ count: missingOperationCount })}
+        </Callout>
+      )}
+
+      <div className="flex flex-wrap gap-6">
+        {operators.length === 0 ? (
+          <NonIdealState
+            className="my-2"
+            title={t.components.viewer.OperationSetViewer.no_explicit_operators}
+            icon="slash"
+            layout="horizontal"
+          />
         ) : (
-          <div className="flex flex-wrap gap-2">
-            {operatorNames.map((name) => (
-              <Tooltip key={name} content={getLocalizedOperatorName(name, language)}>
-                <OperatorAvatar name={name} className="w-10 h-10" sourceSize={96} />
-              </Tooltip>
-            ))}
-          </div>
+          operators.map(({ operator, skills, modules }) => (
+            <OperatorCard key={operator.name} operator={operator} skills={skills} modules={modules} />
+          ))
         )}
-      </FactItem>
+      </div>
     </div>
   )
 }

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -19,7 +19,7 @@ import { useOperations, type OperationsData } from 'apis/operation'
 import { deleteOperationSet, useOperationSet, useRefreshOperationSets } from 'apis/operation-set'
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
-import { ComponentType, FC, Suspense, useEffect, useState } from 'react'
+import { ComponentType, FC, Suspense, useEffect, useState, useId } from 'react'
 import { copyShortCode } from 'services/operation'
 
 import { FactItem } from 'components/FactItem'
@@ -274,16 +274,22 @@ function useOperationSetOperations(operationSet: OperationSet) {
 function OperationSetViewerOperatorsSection({ operationSet }: { operationSet: OperationSet }) {
   const t = useTranslation()
   const [showOperators, setShowOperators] = useState(true)
+  const operatorsContentId = useId()
   const exceedsAggregationLimit = operationSet.copilotIds.length > 50
 
   return (
     <div className="mb-6">
-      <H4
-        className="inline-flex items-center cursor-pointer hover:opacity-80"
-        onClick={() => setShowOperators((visible) => !visible)}
-      >
-        {t.components.viewer.OperationSetViewer.operators}
-        <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
+      <H4 className="inline-flex">
+        <button
+          type="button"
+          className="inline-flex items-center cursor-pointer border-0 bg-transparent p-0 hover:opacity-80"
+          aria-expanded={showOperators}
+          aria-controls={operatorsContentId}
+          onClick={() => setShowOperators((visible) => !visible)}
+        >
+          {t.components.viewer.OperationSetViewer.operators}
+          <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
+        </button>
       </H4>
 
       <Collapse isOpen={showOperators}>
@@ -346,7 +352,7 @@ export function aggregateOperationSetOperators(operations: readonly Operation[])
   const operatorsByName = new Map<string, MutableAggregatedOperator>()
 
   for (const operation of operations) {
-    // 干员组表示“任选其一”，不属于作业集明确指定的所需干员。
+    // opers 不含干员组内干员
     for (const operator of operation.parsedContent.opers ?? []) {
       let aggregated = operatorsByName.get(operator.name)
       if (!aggregated) {

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -30,6 +30,7 @@ import { BanCommentsStatusEnum, CopilotSetStatus } from 'zoot-plus-client'
 
 import { FactItem } from 'components/FactItem'
 import { HelperText } from 'components/HelperText'
+import { OperatorCard } from 'components/OperatorCard'
 import { Paragraphs } from 'components/Paragraphs'
 import { RelativeTime } from 'components/RelativeTime'
 import { withSuspensable } from 'components/Suspensable'
@@ -46,20 +47,11 @@ import { i18nDefer, useTranslation } from '../../i18n/i18n'
 import { CopilotDocV1 } from '../../models/copilot.schema'
 import { createCustomLevel, findLevelByStageName } from '../../models/level'
 import { Level } from '../../models/operation'
-import {
-  OPERATORS,
-  getEliteIconUrl,
-  getModuleName,
-  getSkillCount,
-  useLocalizedOperatorName,
-} from '../../models/operator'
 import { gridModeAtom } from '../../store/pref'
 import { formatError } from '../../utils/error'
 import { ActionCard } from '../ActionCard'
 import { ActionTimelineItem } from '../ActionTimelineItem'
 import { Confirm } from '../Confirm'
-import { MasteryIcon } from '../MasteryIcon'
-import { OperatorAvatar } from '../OperatorAvatar'
 import { ReLinkRenderer } from '../ReLink'
 import { UserName } from '../UserName'
 import { CommentArea } from './comment/CommentArea'
@@ -353,99 +345,6 @@ export const OperationViewer: ComponentType<{
     pendingTitle: i18nDefer.components.viewer.OperationViewer.loading_task,
   },
 )
-
-const OperatorCard: FC<{
-  operator: CopilotDocV1.Operator
-}> = ({ operator }) => {
-  const t = useTranslation()
-  const displayName = useLocalizedOperatorName(operator.name)
-  const info = OPERATORS.find((o) => o.name === operator.name)
-  const { level, elite, skillLevel, module } = operator.requirements ?? {}
-  const skillCount = info ? Math.max(getSkillCount(info), operator.skill ?? 1) : 3
-
-  return (
-    <div className="relative flex items-start">
-      <div className="relative w-20">
-        <div className="relative rounded-lg overflow-hidden shadow-md">
-          <OperatorAvatar
-            id={info?.id}
-            rarity={info?.rarity}
-            className="w-20 h-20"
-            fallback={displayName}
-            sourceSize={96}
-          />
-          {module !== undefined && module !== CopilotDocV1.Module.Default && (
-            <div
-              title={t.components.viewer.OperationViewer.module_title({
-                count: module,
-                name: getModuleName(module),
-              })}
-              className="absolute -bottom-1 right-1 font-serif font-bold text-lg text-white [text-shadow:0_0_3px_#a855f7,0_0_5px_#a855f7]"
-            >
-              {module === CopilotDocV1.Module.Original ? <Icon icon="small-square" /> : getModuleName(module)}
-            </div>
-          )}
-        </div>
-        <h4 className="mt-1 -mx-2 leading-4 font-semibold tracking-tighter text-center">{displayName}</h4>
-        {info && info.prof !== 'TOKEN' && (
-          <img
-            className="absolute top-0 right-0 w-5 h-5 p-px bg-gray-600 rounded-tr-md"
-            src={'/assets/prof-icons/' + info.prof + '.png'}
-            alt={info.prof}
-          />
-        )}
-      </div>
-      {level !== undefined && elite !== undefined && (
-        <div className="absolute -top-2 -left-4 flex items-center flex-col-reverse">
-          <div className="-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
-            <img
-              className="w-7 h-6 object-contain pointer-events-auto"
-              src={getEliteIconUrl(elite)}
-              alt={t.models.operator.elite({ level: elite })}
-            />
-          </div>
-          <div className="w-8 h-8 leading-7 rounded-full border-2 border-yellow-300 bg-black/50 text-lg text-white font-semibold text-center shadow-[0_1px_2px_rgba(0,0,0,0.9)]">
-            {level}
-          </div>
-        </div>
-      )}
-
-      <ul className="flex flex-col gap-1 ml-1">
-        {Array.from({ length: skillCount }, (_, index) => {
-          const skillNumber = index + 1
-          const selected = operator.skill === skillNumber
-          return (
-            <li
-              key={index}
-              className={clsx(
-                'relative',
-                selected
-                  ? 'bg-purple-100 dark:bg-purple-900 dark:text-purple-200 text-purple-800'
-                  : 'bg-gray-300 dark:bg-gray-600 opacity-15 dark:opacity-25',
-              )}
-              title={t.models.operator.skill_number({ count: skillNumber })}
-            >
-              <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
-                {selected &&
-                  (skillLevel === undefined ? (
-                    <Icon icon="tick" />
-                  ) : skillLevel <= 7 ? (
-                    skillLevel
-                  ) : (
-                    <MasteryIcon
-                      className="w-4 h-4"
-                      mastery={skillLevel - 7}
-                      subClassName="fill-gray-300 dark:fill-gray-500"
-                    />
-                  ))}
-              </div>
-            </li>
-          )
-        })}
-      </ul>
-    </div>
-  )
-}
 
 function OperationViewerInner({
   levels,

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -24,7 +24,7 @@ import { ErrorBoundary } from '@sentry/react'
 import { banComments, deleteOperation, rateOperation, useOperation, useRefreshOperations } from 'apis/operation'
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
-import { ComponentType, FC, useEffect, useState } from 'react'
+import { ComponentType, FC, useEffect, useId, useState } from 'react'
 import { copyShortCode, handleDownloadJSON } from 'services/operation'
 import { BanCommentsStatusEnum, CopilotSetStatus } from 'zoot-plus-client'
 
@@ -480,17 +480,23 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
   const [showOperators, setShowOperators] = useState(true)
   const [showActions, setShowActions] = useState(false)
   const [gridMode, setGridMode] = useAtom(gridModeAtom)
+  const operatorsContentId = useId()
 
   const isVideo = operation.type === CopilotType.VIDEO
 
   return (
     <div>
-      <H4
-        className="inline-flex items-center cursor-pointer hover:opacity-80"
-        onClick={() => setShowOperators((v) => !v)}
-      >
-        {t.components.viewer.OperationViewer.operators_and_groups}
-        <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
+      <H4 className="inline-flex">
+        <button
+          type="button"
+          className="inline-flex items-center cursor-pointer border-0 bg-transparent p-0 hover:opacity-80"
+          aria-expanded={showOperators}
+          aria-controls={operatorsContentId}
+          onClick={() => setShowOperators((v) => !v)}
+        >
+          {t.components.viewer.OperationViewer.operators_and_groups}
+          <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
+        </button>
       </H4>
       <details className="inline">
         <summary className="inline cursor-pointer">
@@ -505,38 +511,40 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
           </p>
         </Callout>
       </details>
-      <Collapse isOpen={showOperators}>
-        <div className="mt-2 flex flex-wrap gap-6">
-          {!operation.parsedContent.opers?.length && !operation.parsedContent.groups?.length && (
-            <NonIdealState
-              className="my-2"
-              title={t.components.viewer.OperationViewer.no_operators}
-              description={t.components.viewer.OperationViewer.no_operators_added}
-              icon="slash"
-              layout="horizontal"
-            />
-          )}
-          {operation.parsedContent.opers?.map((operator) => (
-            <OperatorCard key={operator.name} operator={operator} />
-          ))}
-        </div>
-        <div className="flex flex-wrap gap-4 mt-4">
-          {operation.parsedContent.groups?.map((group) => (
-            <Card elevation={Elevation.ONE} className="!p-2 flex flex-col items-center" key={group.name}>
-              <H6 className="mb-3 text-gray-800">{group.name}</H6>
-              <div className="flex flex-wrap px-2 gap-6">
-                {group.opers?.filter(Boolean).map((operator) => (
-                  <OperatorCard key={operator.name} operator={operator} />
-                ))}
+      <div id={operatorsContentId}>
+        <Collapse isOpen={showOperators}>
+          <div className="mt-2 flex flex-wrap gap-6">
+            {!operation.parsedContent.opers?.length && !operation.parsedContent.groups?.length && (
+              <NonIdealState
+                className="my-2"
+                title={t.components.viewer.OperationViewer.no_operators}
+                description={t.components.viewer.OperationViewer.no_operators_added}
+                icon="slash"
+                layout="horizontal"
+              />
+            )}
+            {operation.parsedContent.opers?.map((operator) => (
+              <OperatorCard key={operator.name} operator={operator} />
+            ))}
+          </div>
+          <div className="flex flex-wrap gap-4 mt-4">
+            {operation.parsedContent.groups?.map((group) => (
+              <Card elevation={Elevation.ONE} className="!p-2 flex flex-col items-center" key={group.name}>
+                <H6 className="mb-3 text-gray-800">{group.name}</H6>
+                <div className="flex flex-wrap px-2 gap-6">
+                  {group.opers?.filter(Boolean).map((operator) => (
+                    <OperatorCard key={operator.name} operator={operator} />
+                  ))}
 
-                {group.opers?.filter(Boolean).length === 0 && (
-                  <span className="text-zinc-500">{t.components.viewer.OperationViewer.no_operator}</span>
-                )}
-              </div>
-            </Card>
-          ))}
-        </div>
-      </Collapse>
+                  {group.opers?.filter(Boolean).length === 0 && (
+                    <span className="text-zinc-500">{t.components.viewer.OperationViewer.no_operator}</span>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        </Collapse>
+      </div>
 
       <div className="mt-6 flex items-center gap-4">
         {isVideo ? (

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2916,15 +2916,15 @@
           "cn": "无所需干员",
           "en": "No required operators"
         },
-        "operators_over_limit": {
+        "operations_over_limit": {
           "cn": "作业数量过多，请自行核对所需干员。",
-          "en": "There are too many tasks; please check the required operators yourself."
+          "en": "There are too many operations; please check the required operators yourself."
         },
-        "operators_incomplete": {
+        "operations_incomplete": {
           "cn": "{{count}} 个作业无法读取，所需干员汇总可能不完整。",
           "en": {
-            "1": "{{count}} Job could not be read, so the required operator summary may be incomplete.",
-            "other": "{{count}} Jobs could not be read, so the required operator summary may be incomplete."
+            "1": "{{count}} operation could not be read, so the required operator summary may be incomplete.",
+            "other": "{{count}} operations could not be read, so the required operator summary may be incomplete."
           }
         },
         "render_preview_problem": {

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2913,15 +2913,15 @@
           "en": "Required Operators"
         },
         "no_explicit_operators": {
-          "cn": "没有明确指定的所需干员",
-          "en": "No explicitly required operators"
+          "cn": "无所需干员",
+          "en": "No required operators"
         },
         "operators_over_limit": {
-          "cn": "作业数量超过 50，无法汇总所需干员",
-          "en": "This Job Set has more than 50 Jobs, so required operators cannot be summarized."
+          "cn": "作业数量过多，请自行核对所需干员。",
+          "en": "There are too many tasks; please check the required operators yourself."
         },
         "operators_incomplete": {
-          "cn": "有 {{count}} 个作业无法读取，所需干员汇总可能不完整。",
+          "cn": "{{count}} 个作业无法读取，所需干员汇总可能不完整。",
           "en": {
             "1": "{{count}} Job could not be read, so the required operator summary may be incomplete.",
             "other": "{{count}} Jobs could not be read, so the required operator summary may be incomplete."

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -594,7 +594,7 @@
             "0": "{{count}}星（通常为召唤物）",
             "other": "{{count}}星"
           },
-          "en":{
+          "en": {
             "0": "{{count}}-star (usually a summon)",
             "other": "{{count}}-star"
           }

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2912,9 +2912,24 @@
           "cn": "所需干员",
           "en": "Required Operators"
         },
-        "no_operators": {
-          "cn": "无干员",
-          "en": "No operators"
+        "operators_help": {
+          "cn": "仅汇总各作业明确指定的干员，不包含干员组中的可替换候选。同一干员只显示一次，其技能、养成要求和模组会合并展示。",
+          "en": "Only operators explicitly specified by each Job are included; substitutes in operator groups are excluded. Each operator appears once, with skills, development requirements, and modules merged."
+        },
+        "no_explicit_operators": {
+          "cn": "没有明确指定的所需干员",
+          "en": "No explicitly required operators"
+        },
+        "operators_over_limit": {
+          "cn": "作业数量超过 50，无法汇总所需干员",
+          "en": "This Job Set has more than 50 Jobs, so required operators cannot be summarized."
+        },
+        "operators_incomplete": {
+          "cn": "有 {{count}} 个作业无法读取，所需干员汇总可能不完整。",
+          "en": {
+            "1": "{{count}} Job could not be read, so the required operator summary may be incomplete.",
+            "other": "{{count}} Jobs could not be read, so the required operator summary may be incomplete."
+          }
         },
         "render_preview_problem": {
           "cn": "渲染此作业集的预览时出现了问题 Σ(っ °Д °;)っ",

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2912,10 +2912,6 @@
           "cn": "所需干员",
           "en": "Required Operators"
         },
-        "operators_help": {
-          "cn": "仅汇总各作业明确指定的干员，不包含干员组中的可替换候选。同一干员只显示一次，其技能、养成要求和模组会合并展示。",
-          "en": "Only operators explicitly specified by each Job are included; substitutes in operator groups are excluded. Each operator appears once, with skills, development requirements, and modules merged."
-        },
         "no_explicit_operators": {
           "cn": "没有明确指定的所需干员",
           "en": "No explicitly required operators"


### PR DESCRIPTION
> [!NOTE]
> 代码使用 `gpt-5.6-sol` 生成，已确保编译通过

本 PR 主要做了如下工作：

- 独立 `OperatorCard.tsx` 以供作业/作业集 viewer 共同使用
- 将 #610 加入的所需干员头像区域改为 `OperatorCard`
- ~~微调干员卡片的技能显示效果(移除了 tick icon 改为使用数字)~~

示意图：
<img width="2768" height="1538" alt="PixPin_2026-08-29_23-41-33" src="https://github.com/user-attachments/assets/e7efa300-3951-4021-a9f8-91971fa3a7c9" />

作业数量 > 50; 示例为 opset=42531
<img width="2768" height="1538" alt="image" src="https://github.com/user-attachments/assets/e889e6d4-0e1f-4543-bfe7-4a99050b726f" />

部分作业无法读取（私有/删除）; 示例为 opset=52476
<img width="2768" height="1538" alt="PixPin_2026-08-29_23-43-15" src="https://github.com/user-attachments/assets/7382645d-c213-4842-b354-2c6671a36a26" />

无干员; 示例为 opset=35508
<img width="2768" height="1538" alt="image" src="https://github.com/user-attachments/assets/3785f4e0-d12e-45ba-92d6-a36e044bde0d" />

## Sourcery 总结

为作业集查看器增加统一的干员卡片汇总展示，并完善相关状态提示与交互体验。

新功能：
- 为作业集查看器添加可折叠的所需干员卡片展示，汇总各作业中的技能、等级、精英化和模组信息。
- 为作业集加载失败、作业数量超限、部分作业缺失及无明确干员等情况提供状态提示。

错误修复：
- 改善作业和作业集查看器中干员信息区域的可访问性与交互语义。

增强功能：
- 抽取可复用的 `OperatorCard` 组件，统一作业与作业集中的干员展示。
- 优化作业集干员排序、重复干员合并及技能等级显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为作业集 viewer 增加统一的干员卡片汇总展示，并完善相关状态提示与交互体验。

New Features:
- 为作业集 viewer 添加可折叠的所需干员卡片展示，汇总各作业中的技能、等级、精英化和模组信息。
- 为作业集加载失败、作业数量超限、部分作业缺失及无明确干员等情况提供状态提示。

Bug Fixes:
- 改善作业和作业集 viewer 中干员信息区域的可访问性与交互语义。

Enhancements:
- 抽取可复用的 OperatorCard 组件，统一作业与作业集中的干员展示。
- 优化作业集干员排序、重复干员合并及技能等级显示。

</details>