### PR TITLE
fix: 作业集所需干员聚合包含干员组内干员

### DIFF
--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -356,6 +356,8 @@ export interface AggregatedOperatorGroupTitleSegment {
 }
 
 export interface AggregatedOperatorGroup {
+  /** 干员清单指纹，全局唯一，作为组卡片的稳定 React key */
+  key: string
   titleSegments: AggregatedOperatorGroupTitleSegment[]
   operators: AggregatedOperator[]
 }
@@ -490,7 +492,8 @@ export function aggregateOperationSetOperators(operations: readonly Operation[])
 
   return {
     operators: finalizeAggregatedOperators(operatorsByName),
-    groups: Array.from(groupsByFingerprint.values(), ({ titleSegments, operatorsByName }) => ({
+    groups: Array.from(groupsByFingerprint, ([key, { titleSegments, operatorsByName }]) => ({
+      key,
       titleSegments,
       operators: finalizeAggregatedOperators(operatorsByName),
     })),
@@ -548,8 +551,8 @@ function OperationSetViewerOperators({
 
       {groups.length > 0 && (
         <div className="flex flex-wrap gap-4 mt-4">
-          {groups.map((group, index) => (
-            <Card elevation={Elevation.ONE} className="!p-2 flex flex-col items-center" key={index}>
+          {groups.map((group) => (
+            <Card elevation={Elevation.ONE} className="!p-2 flex flex-col items-center" key={group.key}>
               <H6 className="mb-3 text-gray-800">{formatAggregatedOperatorGroupTitle(group.titleSegments)}</H6>
               <div className="flex flex-wrap px-2 gap-6">
                 {group.operators.map(({ operator, skills, modules }) => (

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -2,10 +2,13 @@ import {
   Alert,
   Button,
   Callout,
+  Card,
   Collapse,
+  Elevation,
   H3,
   H4,
   H5,
+  H6,
   Icon,
   Menu,
   MenuItem,
@@ -346,67 +349,87 @@ interface MutableAggregatedOperator {
   requirements?: Pick<CopilotDocV1.Requirements, 'elite' | 'level'>
 }
 
+/** 干员组卡片的标题段：一个来源组的组名与其所属作业的标题 */
+export interface AggregatedOperatorGroupTitleSegment {
+  groupName: string
+  operationTitle: string
+}
+
+export interface AggregatedOperatorGroup {
+  titleSegments: AggregatedOperatorGroupTitleSegment[]
+  operators: AggregatedOperator[]
+}
+
+interface MutableAggregatedOperatorGroup {
+  titleSegments: AggregatedOperatorGroupTitleSegment[]
+  operatorsByName: Map<string, MutableAggregatedOperator>
+}
+
 const OPERATOR_ORDER = new Map(
   OPERATORS.map((operator, index) => [operator.name, { rarity: operator.rarity, index }] as const),
 )
 
-export function aggregateOperationSetOperators(operations: readonly Operation[]): AggregatedOperator[] {
-  const operatorsByName = new Map<string, MutableAggregatedOperator>()
+/** 技能等级、精英/等级取最高，模组取并集；普通干员与干员组内干员共用 */
+function mergeOperatorIntoAggregated(aggregated: MutableAggregatedOperator, operator: CopilotDocV1.Operator): void {
+  const { elite, level, skillLevel, module } = operator.requirements ?? {}
 
-  for (const operation of operations) {
-    // opers 不含干员组内干员
-    for (const operator of operation.parsedContent.opers ?? []) {
-      let aggregated = operatorsByName.get(operator.name)
-      if (!aggregated) {
-        aggregated = {
-          name: operator.name,
-          skills: new Map(),
-          modules: new Set(),
-        }
-        operatorsByName.set(operator.name, aggregated)
-      }
-
-      const { elite, level, skillLevel, module } = operator.requirements ?? {}
-
-      if (operator.skill !== undefined) {
-        const currentSkillLevel = aggregated.skills.get(operator.skill)
-        if (
-          !aggregated.skills.has(operator.skill) ||
-          (skillLevel !== undefined && (currentSkillLevel === undefined || skillLevel > currentSkillLevel))
-        ) {
-          aggregated.skills.set(operator.skill, skillLevel)
-        }
-      }
-
-      if (
-        elite !== undefined &&
-        level !== undefined &&
-        (!aggregated.requirements ||
-          elite > aggregated.requirements.elite! ||
-          (elite === aggregated.requirements.elite && level > aggregated.requirements.level!))
-      ) {
-        aggregated.requirements = { elite, level }
-      }
-
-      if (module !== undefined && module !== CopilotDocV1.Module.Default) {
-        aggregated.modules.add(module)
-      }
+  if (operator.skill !== undefined) {
+    const currentSkillLevel = aggregated.skills.get(operator.skill)
+    if (
+      !aggregated.skills.has(operator.skill) ||
+      (skillLevel !== undefined && (currentSkillLevel === undefined || skillLevel > currentSkillLevel))
+    ) {
+      aggregated.skills.set(operator.skill, skillLevel)
     }
   }
 
-  return Array.from(operatorsByName.values())
-    .sort((a, b) => {
-      const aOrder = OPERATOR_ORDER.get(a.name)
-      const bOrder = OPERATOR_ORDER.get(b.name)
+  if (
+    elite !== undefined &&
+    level !== undefined &&
+    (!aggregated.requirements ||
+      elite > aggregated.requirements.elite! ||
+      (elite === aggregated.requirements.elite && level > aggregated.requirements.level!))
+  ) {
+    aggregated.requirements = { elite, level }
+  }
 
-      if (aOrder && bOrder) {
-        return bOrder.rarity - aOrder.rarity || aOrder.index - bOrder.index
-      }
-      if (aOrder) return -1
-      if (bOrder) return 1
-      if (a.name === b.name) return 0
-      return a.name < b.name ? -1 : 1
-    })
+  if (module !== undefined && module !== CopilotDocV1.Module.Default) {
+    aggregated.modules.add(module)
+  }
+}
+
+function getOrCreateAggregatedOperator(
+  operatorsByName: Map<string, MutableAggregatedOperator>,
+  name: string,
+): MutableAggregatedOperator {
+  let aggregated = operatorsByName.get(name)
+  if (!aggregated) {
+    aggregated = {
+      name,
+      skills: new Map(),
+      modules: new Set(),
+    }
+    operatorsByName.set(name, aggregated)
+  }
+  return aggregated
+}
+
+function compareAggregatedOperators(a: MutableAggregatedOperator, b: MutableAggregatedOperator) {
+  const aOrder = OPERATOR_ORDER.get(a.name)
+  const bOrder = OPERATOR_ORDER.get(b.name)
+
+  if (aOrder && bOrder) {
+    return bOrder.rarity - aOrder.rarity || aOrder.index - bOrder.index
+  }
+  if (aOrder) return -1
+  if (bOrder) return 1
+  if (a.name === b.name) return 0
+  return a.name < b.name ? -1 : 1
+}
+
+function finalizeAggregatedOperators(operatorsByName: Map<string, MutableAggregatedOperator>): AggregatedOperator[] {
+  return Array.from(operatorsByName.values())
+    .sort(compareAggregatedOperators)
     .map(({ name, requirements, skills, modules }) => ({
       operator: {
         name,
@@ -417,6 +440,76 @@ export function aggregateOperationSetOperators(operations: readonly Operation[])
     }))
 }
 
+export function aggregateOperationSetOperators(operations: readonly Operation[]): {
+  operators: AggregatedOperator[]
+  groups: AggregatedOperatorGroup[]
+} {
+  const operatorsByName = new Map<string, MutableAggregatedOperator>()
+  // 以排序后的干员名清单为指纹：仅清单完全一致的干员组（跨作业、组名可不同）才允许合并，
+  // 清单有任何差异的组各自独立成卡片
+  const groupsByFingerprint = new Map<string, MutableAggregatedOperatorGroup>()
+
+  for (const operation of operations) {
+    // opers 不含干员组内干员
+    for (const operator of operation.parsedContent.opers ?? []) {
+      mergeOperatorIntoAggregated(getOrCreateAggregatedOperator(operatorsByName, operator.name), operator)
+    }
+
+    for (const group of operation.parsedContent.groups ?? []) {
+      // 老数据中组内 opers 可能混入空元素；空组无信息量，直接跳过
+      const groupOpers = (group.opers ?? []).filter((oper) => !!oper)
+      if (groupOpers.length === 0) continue
+
+      const fingerprint = groupOpers
+        .map((oper) => oper.name)
+        .sort()
+        .join('\n')
+
+      let aggregatedGroup = groupsByFingerprint.get(fingerprint)
+      if (!aggregatedGroup) {
+        aggregatedGroup = {
+          titleSegments: [],
+          operatorsByName: new Map(),
+        }
+        groupsByFingerprint.set(fingerprint, aggregatedGroup)
+      }
+
+      aggregatedGroup.titleSegments.push({
+        groupName: group.name,
+        operationTitle: operation.parsedContent.doc.title,
+      })
+
+      for (const operator of groupOpers) {
+        mergeOperatorIntoAggregated(
+          getOrCreateAggregatedOperator(aggregatedGroup.operatorsByName, operator.name),
+          operator,
+        )
+      }
+    }
+  }
+
+  return {
+    operators: finalizeAggregatedOperators(operatorsByName),
+    groups: Array.from(groupsByFingerprint.values(), ({ titleSegments, operatorsByName }) => ({
+      titleSegments,
+      operators: finalizeAggregatedOperators(operatorsByName),
+    })),
+  }
+}
+
+/** 同名簇：组名只写一次，各来源作业标题依次排列，如「奶【SR-5】【SR-7】」；
+ * 异名簇：每段「组名【作业标题】」以管道符分隔，如「奶【SR-5】 | 治疗【SR-6】」 */
+export function formatAggregatedOperatorGroupTitle(
+  titleSegments: readonly AggregatedOperatorGroupTitleSegment[],
+): string {
+  const groupNames = new Set(titleSegments.map(({ groupName }) => groupName))
+  if (groupNames.size === 1) {
+    const titles = titleSegments.map(({ operationTitle }) => `【${operationTitle}】`).join('')
+    return `${titleSegments[0].groupName}${titles}`
+  }
+  return titleSegments.map(({ groupName, operationTitle }) => `${groupName}【${operationTitle}】`).join(' | ')
+}
+
 function OperationSetViewerOperators({
   operationSet,
   operations,
@@ -425,7 +518,7 @@ function OperationSetViewerOperators({
   operations: Operation[]
 }) {
   const t = useTranslation()
-  const operators = aggregateOperationSetOperators(operations)
+  const { operators, groups } = aggregateOperationSetOperators(operations)
   const expectedOperationIds = new Set(operationSet.copilotIds)
   const loadedOperationIds = new Set(operations.map((operation) => operation.id))
   const missingOperationCount = Array.from(expectedOperationIds).filter((id) => !loadedOperationIds.has(id)).length
@@ -439,7 +532,7 @@ function OperationSetViewerOperators({
       )}
 
       <div className="flex flex-wrap gap-6">
-        {operators.length === 0 ? (
+        {operators.length === 0 && groups.length === 0 ? (
           <NonIdealState
             className="my-2"
             title={t.components.viewer.OperationSetViewer.no_explicit_operators}
@@ -452,6 +545,21 @@ function OperationSetViewerOperators({
           ))
         )}
       </div>
+
+      {groups.length > 0 && (
+        <div className="flex flex-wrap gap-4 mt-4">
+          {groups.map((group, index) => (
+            <Card elevation={Elevation.ONE} className="!p-2 flex flex-col items-center" key={index}>
+              <H6 className="mb-3 text-gray-800">{formatAggregatedOperatorGroupTitle(group.titleSegments)}</H6>
+              <div className="flex flex-wrap px-2 gap-6">
+                {group.operators.map(({ operator, skills, modules }) => (
+                  <OperatorCard key={operator.name} operator={operator} skills={skills} modules={modules} />
+                ))}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 问题

作业集「所需干员」此前仅聚合各作业的 `opers`，遗漏 `groups` 中的干员，导致组内干员不显示。

示例：作业集 https://prts.plus/?opset=53006 中「SR-5 - 月斜 初版」「SR-7 - 月悬 初版」各有一个干员组「奶」（华法琳、纯烬艾雅法拉、闪灵），页面上完全缺失。

## 改动

- 聚合时遍历 `groups[].opers`，以排序后的干员名清单为指纹：仅清单完全一致的干员组跨作业合并（组名可不同），清单有差异的组各自独立成卡片
- 卡片标题以「组名【作业标题】」标注来源：同名簇组名只写一次、各来源作业标题依次排列，如 `奶【SR-5 - 月斜 初版】【SR-7 - 月悬 初版】`；异名簇各段以管道符分隔，如 `奶【SR-5 - 月斜 初版】 | 治疗【SR-6 - 月蚀 初版】`
- 组内干员的技能等级、精英/等级、模组合并规则与普通干员一致（取最高/并集）；空组跳过、组内空元素过滤
- 干员组卡片样式对齐单个作业 viewer（`OperationViewer`）的组卡片展示

## 验证

- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` 通过
- 用线上 opset=53006 真实数据跑聚合：产出 1 个组卡片，标题 `奶【SR-5 - 月斜 初版】【SR-7 - 月悬 初版】`，组内含纯烬艾雅法拉、闪灵、华法琳；普通干员 9 人不变
- 边界用例：清单不一致不合并、异名簇标题格式、空组跳过、技能等级取最高均符合预期

## Sourcery 摘要

将行动组成员纳入行动集所需干员的聚合结果，并在合并后的组卡片中展示这些成员。

新功能：
- 聚合并显示行动集需求中行动组内的干员。

错误修复：
- 将之前从所需干员聚合结果中遗漏的行动组成员纳入其中。

增强功能：
- 根据干员成员关系合并匹配的行动组，同时保留来源行动标题，并区分成员关系不同的行动组。
- 对行动组内的干员统一聚合技能等级、精英化与等级要求，以及模组信息。
- 使行动集组卡片的展示方式与现有行动查看器保持一致，并安全处理空行动组。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将操作组成员纳入聚合操作集的操作员要求，并在来源感知的组卡片中呈现合并后的要求。

新功能：
- 将操作组中的操作员纳入操作集所需操作员结果，并将其显示为组卡片。

错误修复：
- 显示之前在聚合操作集要求中被遗漏的组成员。

增强功能：
- 根据操作员成员关系合并匹配的组，同时保留来源操作标题，并将成员关系不同的组分开。
- 对组成员一致地聚合技能、晋升/等级和模块要求，并使组卡片的呈现方式与操作查看器保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include operation-group members in aggregated operation-set operator requirements and present their merged requirements in source-aware group cards.

New Features:
- Include operators from operation groups in operation-set required-operator results and display them as group cards.

Bug Fixes:
- Show group members that were previously omitted from aggregated operation-set requirements.

Enhancements:
- Merge matching groups by their operator membership while preserving source operation titles and keeping groups with different memberships separate.
- Apply consistent aggregation of skill, promotion/level, and module requirements to group members and align group-card presentation with the operation viewer.

</details>

</details>