### PR TITLE
fix: 迁移 v2 作业时处理干员组内干员的模组

### DIFF
--- a/src/models/converter.ts
+++ b/src/models/converter.ts
@@ -34,28 +34,37 @@ export function migrateOperation(operation: CopilotDocV1.Operation): CopilotDocV
     return {
       ...operation,
       version: CopilotDocV1.VERSION,
-      opers: operation.opers?.map((operator) => {
-        if (operator.requirements?.module === undefined) {
-          return operator
-        }
-        const modules = findOperatorByName(operator.name)?.modules
-        if (!modules) {
-          return operator
-        }
-        const actualModuleName = modules[operator.requirements.module]
-        const actualModule =
-          actualModuleName in CopilotDocV1.Module
-            ? (CopilotDocV1.Module[actualModuleName] as CopilotDocV1.Module)
-            : CopilotDocV1.Module.Default
-        return {
-          ...operator,
-          requirements: {
-            ...operator.requirements,
-            module: actualModule,
-          },
-        }
-      }),
+      opers: migrateOperatorsModule(operation.opers),
+      // groups 内的干员同样存在 v2 模组索引，需要一并迁移
+      groups: operation.groups?.map((group) => ({
+        ...group,
+        opers: migrateOperatorsModule(group.opers),
+      })),
     }
   }
   return operation
+}
+
+function migrateOperatorsModule(opers?: CopilotDocV1.Operator[]): CopilotDocV1.Operator[] | undefined {
+  return opers?.map((operator) => {
+    if (operator.requirements?.module === undefined) {
+      return operator
+    }
+    const modules = findOperatorByName(operator.name)?.modules
+    if (!modules) {
+      return operator
+    }
+    const actualModuleName = modules[operator.requirements.module]
+    const actualModule =
+      actualModuleName in CopilotDocV1.Module
+        ? (CopilotDocV1.Module[actualModuleName] as CopilotDocV1.Module)
+        : CopilotDocV1.Module.Default
+    return {
+      ...operator,
+      requirements: {
+        ...operator.requirements,
+        module: actualModule,
+      },
+    }
+  })
 }


### PR DESCRIPTION
## 问题

`migrateOperation` 在迁移 `version: 2` 作业时，模组字段的转换（v2 中 `requirements.module` 为干员模组数组的索引，需映射为 `CopilotDocV1.Module` 枚举）只处理了顶层 `opers`，遗漏 `groups[].opers`，导致组内干员的模组显示错误。

## 改动

- 将单批干员的模组迁移逻辑抽为 `migrateOperatorsModule`，顶层 `opers` 与 `groups[].opers` 共用

## 验证

- `pnpm typecheck` / `pnpm lint` / `pnpm format:check` 通过
- 本地构造 v2 样例走 `toCopilotOperation`：组内干员模组索引 `0` 正确转为 `Default(-1)`（修复前会原样保留 `0`），`version` 2 → 3 正常
- 与 #620 无代码依赖、无文件冲突，可独立审核合并

## Sourcery 摘要

修复版本 2 操作迁移问题，确保顶层运算符和分组运算符的模块要求都能正确转换。

错误修复：
- 转换版本 2 操作时，正确迁移嵌套在分组中的运算符的模块索引。

增强功能：
- 在顶层运算符和分组运算符之间共享运算符模块迁移逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix version 2 operation migration so module requirements are converted correctly for both top-level and grouped operators.

Bug Fixes:
- Correctly migrate module indices for operators nested within groups when converting version 2 operations.

Enhancements:
- Share operator module migration logic between top-level and grouped operators.

</details>