### PR TITLE
feat: 作业集所需干员区块标题与说明提示对齐作业侧

### DIFF
--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -34,6 +34,7 @@ import { withSuspensable } from 'components/Suspensable'
 import { AppToaster } from 'components/Toaster'
 import { DrawerLayout } from 'components/drawer/DrawerLayout'
 import { OperationSetEditorDialog } from 'components/operation-set/OperationSetEditor'
+import { OperatorsAndGroupsHelpNote } from 'components/viewer/OperatorsAndGroupsHelpNote'
 import { CopilotDocV1 } from 'models/copilot.schema'
 import { Operation } from 'models/operation'
 import { OPERATORS } from 'models/operator'
@@ -290,10 +291,11 @@ function OperationSetViewerOperatorsSection({ operationSet }: { operationSet: Op
           aria-controls={operatorsContentId}
           onClick={() => setShowOperators((visible) => !visible)}
         >
-          {t.components.viewer.OperationSetViewer.operators}
+          {t.components.viewer.OperationSetViewer.operators_and_groups}
           <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
         </button>
       </H4>
+      <OperatorsAndGroupsHelpNote />
 
       <div id={operatorsContentId}>
         <Collapse isOpen={showOperators}>

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -2,7 +2,6 @@ import {
   AnchorButton,
   Button,
   ButtonGroup,
-  Callout,
   Card,
   Collapse,
   Elevation,
@@ -38,6 +37,7 @@ import { AppToaster } from 'components/Toaster'
 import { DrawerLayout } from 'components/drawer/DrawerLayout'
 import { EDifficultyLevel } from 'components/entity/ELevel'
 import { OperationRating } from 'components/viewer/OperationRating'
+import { OperatorsAndGroupsHelpNote } from 'components/viewer/OperatorsAndGroupsHelpNote'
 import { CopilotType, OpRatingType, Operation } from 'models/operation'
 import { authAtom } from 'store/auth'
 import { wrapErrorMessage } from 'utils/wrapErrorMessage'
@@ -498,19 +498,7 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
           <Icon icon="chevron-down" className={clsx('ml-1 transition-transform', showOperators && 'rotate-180')} />
         </button>
       </H4>
-      <details className="inline">
-        <summary className="inline cursor-pointer">
-          <Icon icon="help" size={14} className="ml-2 mb-1 opacity-50" />
-        </summary>
-        <Callout intent="primary" icon={null} className="mb-4">
-          <p>
-            {t.components.viewer.OperationViewer.operators_and_groups_note.jsx({
-              operators: (s) => <b>{s}</b>,
-              groups: (s) => <b>{s}</b>,
-            })}
-          </p>
-        </Callout>
-      </details>
+      <OperatorsAndGroupsHelpNote />
       <div id={operatorsContentId}>
         <Collapse isOpen={showOperators}>
           <div className="mt-2 flex flex-wrap gap-6">

--- a/src/components/viewer/OperatorsAndGroupsHelpNote.tsx
+++ b/src/components/viewer/OperatorsAndGroupsHelpNote.tsx
@@ -10,6 +10,8 @@ export function OperatorsAndGroupsHelpNote() {
     <details className="inline">
       <summary className="inline cursor-pointer">
         <Icon icon="help" size={14} className="ml-2 mb-1 opacity-50" />
+        {/* sr-only 文本而非 aria-label：<summary> 的内容命名（name from content）有全组合 AT 实测支持，aria-label 无直接测试矩阵 */}
+        <span className="sr-only">{t.components.viewer.OperatorsAndGroupsHelpNote.toggle_label}</span>
       </summary>
       <Callout intent="primary" icon={null} className="mb-4">
         <p>

--- a/src/components/viewer/OperatorsAndGroupsHelpNote.tsx
+++ b/src/components/viewer/OperatorsAndGroupsHelpNote.tsx
@@ -1,0 +1,24 @@
+import { Callout, Icon } from '@blueprintjs/core'
+
+import { useTranslation } from '../../i18n/i18n'
+
+/** 「干员与干员组」区块标题右侧的说明提示，作业详情与作业集详情共用 */
+export function OperatorsAndGroupsHelpNote() {
+  const t = useTranslation()
+
+  return (
+    <details className="inline">
+      <summary className="inline cursor-pointer">
+        <Icon icon="help" size={14} className="ml-2 mb-1 opacity-50" />
+      </summary>
+      <Callout intent="primary" icon={null} className="mb-4">
+        <p>
+          {t.components.viewer.OperatorsAndGroupsHelpNote.note.jsx({
+            operators: (s) => <b>{s}</b>,
+            groups: (s) => <b>{s}</b>,
+          })}
+        </p>
+      </Callout>
+    </details>
+  )
+}

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2908,13 +2908,13 @@
           "cn": "作者",
           "en": "Author"
         },
-        "operators": {
-          "cn": "所需干员",
-          "en": "Required Operators"
+        "operators_and_groups": {
+          "cn": "所需干员与干员组",
+          "en": "Required Operators and Groups"
         },
         "no_explicit_operators": {
-          "cn": "无所需干员",
-          "en": "No required operators"
+          "cn": "无所需干员与干员组",
+          "en": "No required operators or operator groups"
         },
         "operations_over_limit": {
           "cn": "作业数量过多，请自行核对所需干员。",
@@ -3085,10 +3085,6 @@
           "cn": "干员与干员组",
           "en": "Operators and Operator Groups"
         },
-        "operators_and_groups_note": {
-          "cn": "{{operators(干员)}}\n作业必需的干员。\n干员练度（等级、模组）仅供参考，客户端的自动编队仅支持技能选择，其余信息暂未支持。\n\n{{groups(干员组)}}\n一系列可替换干员的编组。\n组内干员可以任选其一，客户端自动编队时按最高练度来选择。",
-          "en": "{{operators(Operators)}}\nOperators required for this Job. \nThe requirements (level and module) are for reference only. The client's auto-formation only supports skill selection, and other information is not yet supported.\n\n{{groups(Operator Groups)}}\nGroups of interchangeable operators. \nYou can choose any operator in a group. The client's auto-formation selects the one with the highest level."
-        },
         "no_operators": {
           "cn": "暂无干员",
           "en": "No Operators"
@@ -3162,6 +3158,12 @@
         "type_prts": {
           "cn": "PRTS",
           "en": "PRTS"
+        }
+      },
+      "OperatorsAndGroupsHelpNote": {
+        "note": {
+          "cn": "{{operators(干员)}}\n作业必需的干员。\n干员练度（等级、模组）仅供参考，客户端的自动编队仅支持技能选择，其余信息暂未支持。\n\n{{groups(干员组)}}\n一系列可替换干员的编组。\n组内干员可以任选其一，客户端自动编队时按最高练度来选择。",
+          "en": "{{operators(Operators)}}\nOperators required for this Job. \nThe requirements (level and module) are for reference only. The client's auto-formation only supports skill selection, and other information is not yet supported.\n\n{{groups(Operator Groups)}}\nGroups of interchangeable operators. \nYou can choose any operator in a group. The client's auto-formation selects the one with the highest level."
         }
       }
     },

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -3164,6 +3164,10 @@
         "note": {
           "cn": "{{operators(干员)}}\n作业必需的干员。\n干员练度（等级、模组）仅供参考，客户端的自动编队仅支持技能选择，其余信息暂未支持。\n\n{{groups(干员组)}}\n一系列可替换干员的编组。\n组内干员可以任选其一，客户端自动编队时按最高练度来选择。",
           "en": "{{operators(Operators)}}\nOperators required for this Job. \nThe requirements (level and module) are for reference only. The client's auto-formation only supports skill selection, and other information is not yet supported.\n\n{{groups(Operator Groups)}}\nGroups of interchangeable operators. \nYou can choose any operator in a group. The client's auto-formation selects the one with the highest level."
+        },
+        "toggle_label": {
+          "cn": "干员与干员组说明",
+          "en": "Help for operators and operator groups"
         }
       }
     },


### PR DESCRIPTION
## 变更内容

- 作业集「所需干员」区块标题改为「所需干员与干员组」（en: Required Operators and Groups），i18n 键名 `operators` 同步改为 `operators_and_groups`，与作业侧键命名一致。标题文案刻意保留「所需/Required」前缀差异（作业详情页为「干员与干员组」）：作业集区块是跨作业聚合的所需清单，与作业详情页的内容清单语义不同
- 同区块空状态文案同步改为「无所需干员与干员组」
- 抽取作业详情页的说明提示为共享组件 `OperatorsAndGroupsHelpNote`，在作业集标题右侧展示同款提示；提示文案键随之迁移至 `components.viewer.OperatorsAndGroupsHelpNote.note`（文案内容不变）
- 为说明开关（纯图标 `<summary>`）补充可访问名称：新增 i18n 键 `toggle_label`（cn「干员与干员组说明」），以 `sr-only` 视觉隐藏文本呈现，修复 WCAG 4.1.2 无名称问题；图标本身已由 Blueprint Icon 默认标记 `aria-hidden`

## 验证

- `pnpm generate:i18n && tsc --noEmit` 通过
- SSR 冒烟渲染断言：`<summary>` 含 sr-only 标签文本、图标已 aria-hidden、details/summary 结构与 note 富文本渲染完整
- 本地 dev 目视核对：两侧 help 图标与展开说明为同一组件实现、呈现一致；标题文案保留上述刻意差异

## Sourcery 总结

统一操作视图和操作集视图中的操作员和组标签及指导说明。

改进：
- 通过使用“Required Operators and Groups”标题、匹配空状态并共享帮助指导，使操作集的操作员部分与操作详情保持一致。

杂项：
- 将操作员和组帮助文本的翻译移至共享组件命名空间，同时保留其内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize operator and group labels and guidance across operation and operation set views.

Enhancements:
- Align operation set operator sections with operation details by using the “Required Operators and Groups” title, matching empty state, and shared help guidance.

Chores:
- Move operator and group help translations into the shared component namespace while preserving their content.

</details>